### PR TITLE
[FEAT]: OAUTH 기능 구현

### DIFF
--- a/src/main/java/com/dft/mom/domain/service/CacheOAuthService.java
+++ b/src/main/java/com/dft/mom/domain/service/CacheOAuthService.java
@@ -1,0 +1,38 @@
+package com.dft.mom.domain.service;
+
+import com.dft.mom.web.exception.member.MemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import static com.dft.mom.domain.util.EntityConstants.NON_MEMBER_STR;
+import static com.dft.mom.web.exception.ExceptionType.MORE_FOR_MEMBER;
+
+@Service
+@RequiredArgsConstructor
+public class CacheOAuthService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String PREFIX = "cache:llm:";
+    private static final Duration TTL = Duration.ofHours(24);
+    private static final int MAX_COUNT = 5;
+
+    /* 호출 횟수를 1 증가시키고, 비회원이 5회를 넘으면 예외를 던지는 메서드 */
+    public void increaseAndValidate(String memberId, String role) {
+        String key = PREFIX + memberId;
+        long count = redisTemplate.opsForValue().increment(key);
+
+        if (count == 1L) {
+            redisTemplate.expire(key, TTL);
+        }
+
+        if (NON_MEMBER_STR.equals(role) && count > MAX_COUNT) {
+            throw new MemberException(
+                    MORE_FOR_MEMBER.getCode(),
+                    MORE_FOR_MEMBER.getErrorMessage()
+            );
+        }
+    }
+}

--- a/src/main/java/com/dft/mom/domain/util/CommonConstants.java
+++ b/src/main/java/com/dft/mom/domain/util/CommonConstants.java
@@ -17,6 +17,7 @@ public class CommonConstants {
     public static final Set<String> NON_MEMBER_ROUTE = Set.of(
             "/auth/validate",
             "/auth/reissue",
+            "/oauth",
             "/common/version-check"
     );
 

--- a/src/main/java/com/dft/mom/web/controller/OAuthController.java
+++ b/src/main/java/com/dft/mom/web/controller/OAuthController.java
@@ -1,0 +1,31 @@
+package com.dft.mom.web.controller;
+
+import com.dft.mom.domain.service.CacheOAuthService;
+import com.dft.mom.domain.service.RoleService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import static com.dft.mom.domain.validator.MemberValidator.validateAuthentication;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/oauth")
+public class OAuthController {
+
+    private final RoleService roleService;
+    private final CacheOAuthService authService;
+
+    /*페이지 조회*/
+    @GetMapping
+    public void validateOAuth(
+            Authentication authentication,
+            HttpServletRequest request
+    ) {
+        validateAuthentication(authentication, request);
+        String id = authentication.getName();
+        String role = roleService.getMemberRole(authentication);
+        authService.increaseAndValidate(id, role);
+    }
+}

--- a/src/main/java/com/dft/mom/web/exception/ExceptionType.java
+++ b/src/main/java/com/dft/mom/web/exception/ExceptionType.java
@@ -29,6 +29,7 @@ public enum ExceptionType {
     MULTI_LOGIN(10003, "중복 로그인되었습니다."),
     SOCIAL_CONNECT_FAILED(10004, "소셜 로그인은 진행할 수 없어요!"),
     UN_AUTH_NON_MEMBER(10005, "로그인 먼저 해주세요"),
+    MORE_FOR_MEMBER(10006, "더 많은 사용을 위해 로그인해주세요!"),
 
     /**
      * FAMILY Exception

--- a/src/main/java/com/dft/mom/web/filter/security/BlacklistFilter.java
+++ b/src/main/java/com/dft/mom/web/filter/security/BlacklistFilter.java
@@ -55,6 +55,7 @@ public class BlacklistFilter implements Filter {
                 || requestUri.startsWith("/my")
                 || requestUri.startsWith("/baby")
                 || requestUri.startsWith("/page")
+                || requestUri.startsWith("/oauth")
                 || requestUri.startsWith("/family")
                 || requestUri.startsWith("/error")) {
             return true;

--- a/src/test/java/com/dft/mom/service/OAuthServiceTest.java
+++ b/src/test/java/com/dft/mom/service/OAuthServiceTest.java
@@ -1,0 +1,53 @@
+package com.dft.mom.service;
+
+import com.dft.mom.ServiceTest;
+import com.dft.mom.domain.service.CacheOAuthService;
+import com.dft.mom.web.exception.member.MemberException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.dft.mom.domain.util.EntityConstants.*;
+import static com.dft.mom.web.exception.ExceptionType.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest()
+public class OAuthServiceTest extends ServiceTest {
+
+    @Autowired
+    private CacheOAuthService authService;
+
+    @BeforeEach
+    public void setUp() {}
+
+    @Test
+    @DisplayName("1. 어드민과 회원은 무한접근이 가능하다.")
+    public void 회원은_무한접근이_가능하다() {
+        assertDoesNotThrow(() -> {
+            for (int i = 0; i < 10; i++) {
+                authService.increaseAndValidate("1", ADMIN_STR);
+                authService.increaseAndValidate("2", MEMBER_STR);
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("1. 비회원은 5번까지 접근이 가능하다.")
+    public void 비회원은_다섯번까지_접근이_가능하다() {
+        assertDoesNotThrow(() -> {
+            for (int i = 0; i < 5; i++) {
+                authService.increaseAndValidate("1", NON_MEMBER_STR);
+            }
+        });
+
+        MemberException ex = assertThrows(MemberException.class, () -> authService.increaseAndValidate("1", NON_MEMBER_STR));
+        assertEquals(MORE_FOR_MEMBER.getCode(), ex.getCode());
+    }
+}


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] OAUTH 기능 구현

## 고민과 해결과정
LLM 서비스에서 LLM을 호출하는 과정 전에 유저에 대한 권한을 체크해야한다.
하지만 LLM 서비스에 인가 프로세스를 두는 것은 코드 관리가 복잡해진다.
따라서 API 서버를 인가 서버로서의 역할을 하도록 구현한다.