### PR TITLE
[FEAT] 레디스 장애조치

### DIFF
--- a/src/main/java/com/dft/mom/domain/service/PageService.java
+++ b/src/main/java/com/dft/mom/domain/service/PageService.java
@@ -36,26 +36,7 @@ public class PageService {
             sync = true
     )
     public PageResponseDto getCachedPage(Integer type, Integer period) {
-        BabyPage babyPage = getPage(type, period);
-
-        if (babyPage == null) {
-            return null;
-        }
-
-        if (babyPage.getType() == TYPE_PREGNANCY_GUIDE
-                || babyPage.getType() == TYPE_CHILDCARE_GUIDE) {
-            List<CategoryResponseDto> categoryList = getPageItemWithPost(babyPage);
-            return new PageResponseDto(babyPage, categoryList);
-        }
-
-        if (babyPage.getType() == TYPE_CHILDCARE_NUTRITION
-                || babyPage.getType() == TYPE_PREGNANCY_NUTRITION) {
-            List<CategoryResponseDto> categoryList = getPageItemWithNutrition(babyPage);
-            return new PageResponseDto(babyPage, categoryList);
-        }
-
-        List<CategoryResponseDto> categoryList = getPageItemWithInspection(babyPage);
-        return new PageResponseDto(babyPage, categoryList);
+        return loadPage(type, period);
     }
 
     /* 페이지 업데이트를 통해 캐시 미스 개선 */
@@ -65,8 +46,11 @@ public class PageService {
             key = "'cached-page-' + #type + '-' + #period"
     )
     public PageResponseDto putCachedPage(Integer type, Integer period) {
-        BabyPage babyPage = getPage(type, period);
+        return loadPage(type, period);
+    }
 
+    private PageResponseDto loadPage(Integer type, Integer period) {
+        BabyPage babyPage = getPage(type, period);
         if (babyPage == null) {
             return null;
         }

--- a/src/main/java/com/dft/mom/web/config/NetworkConfig.java
+++ b/src/main/java/com/dft/mom/web/config/NetworkConfig.java
@@ -1,0 +1,16 @@
+package com.dft.mom.web.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+@EnableCaching
+public class NetworkConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] 레디스 장애조치를 위한 추가 설계

## 고민과 해결과정
### 장애조치를 어떻게 할것인가?
기본적으로 두가지 방법이 있다.
1. 장애 발생 시 데이터베이스를 조회한다.
2. 장애 발생 시 로컬 캐시를 활용한다.

1번의 구현은 굉장히 쉽다. 하지만 2번의 경우가 당연히 성능이 더 좋다.
2번의 경우 CacheManager를 직접 구현해야 한다. 따라서 추가 학습을 진행을 먼저 하는게 좋을 것 같다.
따라서 임시로 1번 정책으로 선택한 이후, 학습 후에 2번 정책으로 바꾼다.