### PR TITLE
[FEAT]: 캐시 이중화 및 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	//Redis 라이브러리
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	//로컬 캐시 라이브러리
+	implementation 'com.github.ben-manes.caffeine:caffeine'
+
 	//MEMORY
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 

--- a/src/main/java/com/dft/mom/domain/cache/TwoLevelCache.java
+++ b/src/main/java/com/dft/mom/domain/cache/TwoLevelCache.java
@@ -1,0 +1,111 @@
+package com.dft.mom.domain.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
+
+import java.util.concurrent.Callable;
+
+@RequiredArgsConstructor
+public class TwoLevelCache implements Cache {
+
+    private final Cache redis;
+    private final Cache local;
+
+    @Override
+    public String getName() {
+        return redis.getName();
+    }
+
+    @Override
+    public Object getNativeCache() {
+        return redis.getNativeCache();
+    }
+
+    @Override
+    public ValueWrapper get(Object key) {
+        try {
+            return redis.get(key);
+        } catch (RedisConnectionFailureException | RedisSystemException ex) {
+            return local.get(key);
+        } catch (RuntimeException ex) {
+            if (isRedisConnectionFailure(ex)) {
+                return local.get(key);
+            }
+            throw ex;
+        }
+    }
+
+    @Override
+    public <T> T get(Object key, Class<T> type) {
+        try {
+            return redis.get(key, type);
+        } catch (RedisConnectionFailureException | RedisSystemException ex) {
+            return local.get(key, type);
+        } catch (RuntimeException ex) {
+            if (isRedisConnectionFailure(ex)) {
+                return local.get(key, type);
+            }
+            throw ex;
+        }
+    }
+
+    @Override
+    public <T> T get(Object key, Callable<T> loader) {
+        try {
+            return redis.get(key, loader);
+        } catch (RedisConnectionFailureException | RedisSystemException ex) {
+            return local.get(key, loader);
+        } catch (RuntimeException ex) {
+            if (isRedisConnectionFailure(ex)) {
+                return local.get(key, loader);
+            }
+            throw ex;
+        }
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+        executeSafely(
+                () -> redis.put(key, value),
+                () -> local.put(key, value)
+        );
+    }
+
+    @Override
+    public void evict(Object key) {
+        executeSafely(
+                () -> redis.evict(key),
+                () -> local.evict(key)
+        );
+    }
+
+    @Override
+    public void clear() {
+        executeSafely(
+                redis::clear,
+                local::clear
+        );
+    }
+
+    private boolean isRedisConnectionFailure(RuntimeException ex) {
+        Throwable cause = ex.getCause();
+        return cause instanceof RedisConnectionFailureException
+                || cause instanceof RedisSystemException;
+    }
+
+    private void executeSafely(Runnable primary, Runnable fallback) {
+        try {
+            primary.run();
+        } catch (RedisConnectionFailureException | RedisSystemException ex) {
+            fallback.run();
+        } catch (RuntimeException ex) {
+            if (isRedisConnectionFailure(ex)) {
+                fallback.run();
+                return;
+            }
+            throw ex;
+        }
+    }
+}

--- a/src/main/java/com/dft/mom/domain/cache/TwoLevelCacheManager.java
+++ b/src/main/java/com/dft/mom/domain/cache/TwoLevelCacheManager.java
@@ -1,0 +1,31 @@
+package com.dft.mom.domain.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.Cache;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+@RequiredArgsConstructor
+public class TwoLevelCacheManager implements CacheManager {
+
+    private final CacheManager redisManager;
+    private final CacheManager caffeineManager;
+
+    @Override
+    public Cache getCache(String name) {
+        Cache redis    = redisManager.getCache(name);
+        Cache caffeine = caffeineManager.getCache(name);
+        return new TwoLevelCache(redis, caffeine);
+    }
+
+    @Override
+    public Collection<String> getCacheNames() {
+        Set<String> names = new HashSet<>();
+        names.addAll(redisManager.getCacheNames());
+        names.addAll(caffeineManager.getCacheNames());
+        return names;
+    }
+}

--- a/src/main/java/com/dft/mom/domain/service/PageService.java
+++ b/src/main/java/com/dft/mom/domain/service/PageService.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.dft.mom.domain.util.CommonConstants.PAGE_CACHE_KEY;
 import static com.dft.mom.domain.util.PostConstants.*;
 
 @Service
@@ -31,7 +32,7 @@ public class PageService {
     /* 페이지 캐시를 통해 조회 성능 개선 */
     @Transactional(readOnly = true)
     @Cacheable(
-            value = "pageCache",
+            value = PAGE_CACHE_KEY,
             key = "'cached-page-' + #type + '-' + #period",
             sync = true
     )
@@ -42,7 +43,7 @@ public class PageService {
     /* 페이지 업데이트를 통해 캐시 미스 개선 */
     @Transactional(readOnly = true)
     @CachePut(
-            value = "pageCache",
+            value = PAGE_CACHE_KEY,
             key = "'cached-page-' + #type + '-' + #period"
     )
     public PageResponseDto putCachedPage(Integer type, Integer period) {

--- a/src/main/java/com/dft/mom/domain/service/SubItemService.java
+++ b/src/main/java/com/dft/mom/domain/service/SubItemService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.dft.mom.domain.util.CommonConstants.SUB_ITEM_CACHE_KEY;
 import static com.dft.mom.domain.util.PostConstants.*;
 
 @Service
@@ -24,7 +25,7 @@ public class SubItemService {
     /* 서브 아이템 캐시를 통해 조회 성능 개선 */
     @Transactional(readOnly = true)
     @Cacheable(
-            value = "subItemCache",
+            value = SUB_ITEM_CACHE_KEY,
             key = "'cached-sub-item-' + #type + '-' + #itemId",
             sync = true
     )
@@ -34,7 +35,7 @@ public class SubItemService {
 
     @Transactional(readOnly = true)
     @CachePut(
-            value = "subItemCache",
+            value = SUB_ITEM_CACHE_KEY,
             key = "'cached-sub-item-' + #type + '-' + #itemId"
     )
     public ItemResponseDto putCachedItem(Integer type, Long itemId) {

--- a/src/main/java/com/dft/mom/domain/util/CommonConstants.java
+++ b/src/main/java/com/dft/mom/domain/util/CommonConstants.java
@@ -23,4 +23,8 @@ public class CommonConstants {
 
     //EPOCH
     public static final long EPOCH = 1740787200000L;
+
+    //CACHE KEY
+    public static final String PAGE_CACHE_KEY = "pageCache";
+    public static final String SUB_ITEM_CACHE_KEY = "subItemCache";
 }

--- a/src/test/java/com/dft/mom/service/TwoLevelCacheTest.java
+++ b/src/test/java/com/dft/mom/service/TwoLevelCacheTest.java
@@ -1,0 +1,140 @@
+package com.dft.mom.service;
+
+import com.dft.mom.domain.cache.TwoLevelCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.data.redis.RedisConnectionFailureException;
+
+import java.util.concurrent.Callable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TwoLevelCacheTest {
+
+    @Mock Cache redis;
+    @Mock Cache local;
+    TwoLevelCache cache;
+
+    @BeforeEach
+    void setUp() {
+        cache = new TwoLevelCache(redis, local);
+    }
+
+    @Test
+    @DisplayName("1. REDIS 캐시 미스 시 DB 호출 후")
+    void 캐시테스트1() throws Exception {
+        when(redis.get(eq("k"), any(Callable.class)))
+                .thenAnswer(inv -> {
+                    Callable<String> loader = inv.getArgument(1);
+                    return loader.call();
+                });
+
+        Callable<String> db = mock(Callable.class);
+        when(db.call()).thenReturn("DB");
+
+        assertEquals("DB", cache.get("k", db));
+
+        verify(redis, times(1)).get(eq("k"), any(Callable.class));
+        verify(local, never()).get(any(), any(Callable.class));
+        verify(db, times(1)).call();
+    }
+
+    @Test
+    @DisplayName("2. REDIS 캐시 히트 시 바로 반환")
+    void 캐시테스트2() throws Exception {
+        when(redis.get(eq("k"), any(Callable.class))).thenReturn("R");
+
+        Callable<String> db = mock(Callable.class);
+
+        assertEquals("R", cache.get("k", db));
+        verify(redis).get(eq("k"), any(Callable.class));
+        verify(local, never()).get(any(), any(Callable.class));
+        verify(db, never()).call();
+    }
+
+    @Test
+    @DisplayName("3. REDIS 장애 시 로컬 캐시 미스로 DB 조회 사용")
+    void 캐시테스트3() throws Exception {
+        when(redis.get(eq("k"), any(Callable.class)))
+                .thenThrow(new RuntimeException(new RedisConnectionFailureException("레디스 장애 발생")));
+        when(local.get(eq("k"), any(Callable.class)))
+                .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
+
+        Callable<String> db = mock(Callable.class);
+        when(db.call()).thenReturn("DB");
+
+        assertEquals("DB", cache.get("k", db));
+        verify(redis, times(1)).get(eq("k"), any(Callable.class));
+        verify(local, times(1)).get(eq("k"), any(Callable.class));
+        verify(redis, never()).get(eq("m"), any(Callable.class));
+        verify(local, never()).get(eq("m"), any(Callable.class));
+        verify(db, times(1)).call();
+    }
+
+    @Test
+    @DisplayName("4. REDIS 장애 시 로컬 캐시 사용")
+    void 캐시테스트4() throws Exception {
+        when(redis.get(eq("k"), any(Callable.class)))
+                .thenThrow(new RuntimeException(new RedisConnectionFailureException("레디스 장애 발생")));
+        when(local.get(eq("k"), any(Callable.class))).thenReturn("CACHED");
+        Callable<String> db = mock(Callable.class);
+
+        assertEquals("CACHED", cache.get("k", db));
+        verify(redis, times(1)).get(eq("k"), any(Callable.class));
+        verify(local, times(1)).get(eq("k"), any(Callable.class));
+        verify(redis, never()).get(eq("m"), any(Callable.class));
+        verify(local, never()).get(eq("m"), any(Callable.class));
+        verify(db, never()).call();
+    }
+
+    @Test
+    @DisplayName("5. REDIS PUT 성공 시 로컬 캐시 반영 안됨")
+    void 캐시테스트5() {
+        // when
+        doNothing().when(redis).put("k", "v");
+
+        //given
+        cache.put("k", "v");
+
+        // then
+        verify(redis, times(1)).put("k", "v");
+        verify(local, never()).put(any(), any());
+    }
+
+    @Test
+    @DisplayName("6. REDIS 장애 시 로컬 캐시 반영 됨")
+    void 캐시테스트6() {
+        // when
+        doThrow(new RuntimeException(new RedisConnectionFailureException("레디스 장애 발생")))
+                .when(redis).put("k", "v");
+
+        // given
+        cache.put("k", "v");
+
+        // then
+        verify(redis, times(1)).put("k", "v");
+        verify(local, times(1)).put("k", "v");
+    }
+
+    @Test
+    @DisplayName("7. REDIS 장애 시 로컬 캐시 반영 됨")
+    void 캐시테스트7() {
+        // given when
+        doThrow(new RuntimeException("알수없는 에러")).when(redis).put("k", "v");
+
+        // then
+        assertThrows(RuntimeException.class, () -> cache.put("k", "v"));
+        verify(local, never()).put(any(), any());
+    }
+}


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] 캐시 이중화
- [x] 테스트 코드 작성

## 고민과 해결과정
### 레디스 장애시 데이터베이스 조회가 맞을까?
레디스 장애가 발생했을때 기존 로직은 데이터베이스를 활용한다.
만약 데이터베이스를 활용한다면 이는 캐시라는 기능을 사용하지 않는것이므로 서비스 설계에 적합하지 않다.
따라서 캐시를 이중화하여 레디스를 사용하지 못할 시 로컬 캐시를 활용하게 한다

### 카페인을 사용한 이유
카페인의 캐시 정책인 LRU와 LFU를 동시에 사용하면서 더 좋은 캐시정책을 가진다.
스프링의 캐싱 추상화와의 통합되어 다양한 어노테이션 환경을 사용할 수 있다.
ConcurrentHashMap 사용시 TTL 과 캐시 제거 정책을 직접 구현해야하는데 이 단점을 보완해준다.