### PR TITLE
[FEAT] 인가서버 보안 개선

### DIFF
--- a/src/main/java/com/dft/mom/domain/excel/ExcelCreateService.java
+++ b/src/main/java/com/dft/mom/domain/excel/ExcelCreateService.java
@@ -53,9 +53,9 @@ public class ExcelCreateService {
 
     @PostConstruct
     public void init() throws IOException {
-         exportJsonToExcel("research_post_8_10.json", "excel/createFetalPost.xlsx");
+//         exportJsonToExcel("research_post_8_10.json", "excel/createFetalPost.xlsx");
 //         exportJsonToExcel("research_caution_8_10.json", "excel/createFetalPost.xlsx");
-         exportNutritionJsonToExcel("research_nutrition.json", "excel/createNutrition.xlsx");
+//         exportNutritionJsonToExcel("research_nutrition.json", "excel/createNutrition.xlsx");
     }
 
     /*

--- a/src/main/java/com/dft/mom/domain/excel/ExcelCreateService.java
+++ b/src/main/java/com/dft/mom/domain/excel/ExcelCreateService.java
@@ -53,8 +53,9 @@ public class ExcelCreateService {
 
     @PostConstruct
     public void init() throws IOException {
+         exportJsonToExcel("research_post_8_10.json", "excel/createFetalPost.xlsx");
 //         exportJsonToExcel("research_caution_8_10.json", "excel/createFetalPost.xlsx");
-//         exportNutritionJsonToExcel("research_nutrition.json", "excel/createNutrition.xlsx");
+         exportNutritionJsonToExcel("research_nutrition.json", "excel/createNutrition.xlsx");
     }
 
     /*
@@ -229,6 +230,18 @@ public class ExcelCreateService {
             case "research_post_2_3.json" -> "임신가이드_2_3달";
             case "research_post_4_7.json" -> "임신가이드_4_7달";
             case "research_post_8_10.json" -> "임신가이드_8_10달";
+            case "baby_post_1_2.json" -> "육아가이드_1_2달";
+            case "baby_post_3_4.json" -> "육아가이드_3_4달";
+            case "baby_post_5_6.json" -> "육아가이드_5_6달";
+            case "baby_post_7_8.json" -> "육아가이드_7_8달";
+            case "baby_post_9_10.json" -> "육아가이드_9_10달";
+            case "baby_post_11_12.json" -> "육아가이드_11_12달";
+            case "baby_post_13_15.json" -> "육아가이드_13_15달";
+            case "baby_post_16_18.json" -> "육아가이드_16_18달";
+            case "baby_post_19_24.json" -> "육아가이드_19_24달";
+            case "baby_caution.json" -> "육아가이드_주의";
+            case "baby_attachment.json" -> "육아가이드_애착형성";
+            case "baby_sleep.json" -> "육아가이드_수면관리";
             case "research_caution_2_3.json",
                  "research_caution_4_7.json",
                  "research_caution_8_10.json" -> "임신가이드_주의";

--- a/src/main/java/com/dft/mom/domain/util/CommonConstants.java
+++ b/src/main/java/com/dft/mom/domain/util/CommonConstants.java
@@ -13,7 +13,10 @@ public class CommonConstants {
     public static final String REFRESH_TOKEN = "refreshToken";
 
     //ROUTE FOR NO AUTH
-    public static final Set<String> POSSIBLE_GET_ROUTE = Set.of();
+    public static final Set<String> VALIDATE_GET_ROUTE = Set.of(
+            "/oauth"
+    );
+
     public static final Set<String> NON_MEMBER_ROUTE = Set.of(
             "/auth/validate",
             "/auth/reissue",

--- a/src/main/java/com/dft/mom/web/config/SpringSecurityConfig.java
+++ b/src/main/java/com/dft/mom/web/config/SpringSecurityConfig.java
@@ -8,6 +8,7 @@ import com.dft.mom.web.filter.authorization.JwtAuthorizationRsaFilter;
 import com.dft.mom.web.filter.exception.CustomAuthenticationEntryPoint;
 import com.dft.mom.web.filter.exception.CustomAuthenticationFailureHandler;
 import com.dft.mom.web.filter.security.BlacklistFilter;
+import com.dft.mom.web.filter.security.LLMAuthFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +30,7 @@ public class SpringSecurityConfig {
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final LoginService loginService;
     private final BlacklistFilter blacklistFilter;
+    private final LLMAuthFilter llmAuthFilter;
     private final JwtAuthorizationRsaFilter jwtAuthorizationRsaFilter;
 
     private String[] permitAllUrlPatterns() {
@@ -73,6 +75,7 @@ public class SpringSecurityConfig {
                 .addFilter(jwtKakaoAuthenticationFilter)
                 .addFilter(jwtAppleAuthenticationFilter)
                 .addFilterBefore(jwtAuthorizationRsaFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(llmAuthFilter, JwtAuthorizationRsaFilter.class)
                 .addFilterBefore(blacklistFilter, CorsFilter.class);
 
         return http.build();

--- a/src/main/java/com/dft/mom/web/controller/OAuthController.java
+++ b/src/main/java/com/dft/mom/web/controller/OAuthController.java
@@ -17,6 +17,7 @@ public class OAuthController {
     private final RoleService roleService;
     private final CacheOAuthService authService;
 
+    @GetMapping
     public void validateOAuth(
             Authentication authentication,
             HttpServletRequest request

--- a/src/main/java/com/dft/mom/web/controller/OAuthController.java
+++ b/src/main/java/com/dft/mom/web/controller/OAuthController.java
@@ -17,8 +17,6 @@ public class OAuthController {
     private final RoleService roleService;
     private final CacheOAuthService authService;
 
-    /*페이지 조회*/
-    @GetMapping
     public void validateOAuth(
             Authentication authentication,
             HttpServletRequest request

--- a/src/main/java/com/dft/mom/web/exception/ExceptionType.java
+++ b/src/main/java/com/dft/mom/web/exception/ExceptionType.java
@@ -31,6 +31,7 @@ public enum ExceptionType {
     UN_AUTH_NON_MEMBER(10005, "로그인 먼저 해주세요"),
     MORE_FOR_MEMBER(10006, "더 많은 사용을 위해 로그인해주세요!"),
     DELETED_MEMBER(10007, "탈퇴한 회원입니다"),
+    QUOTA_EXCEED(10008, "일일 사용량을 초과하였습니다"),
 
     /**
      * FAMILY Exception

--- a/src/main/java/com/dft/mom/web/exception/ExceptionType.java
+++ b/src/main/java/com/dft/mom/web/exception/ExceptionType.java
@@ -19,6 +19,7 @@ public enum ExceptionType {
     ENCRYPT_FAIL(90102, "암호화에 실패하였습니다."),
     DECRYPT_FAIL(90103, "복호화에 실패하였습니다."),
     TIME_INVALID(90104, "과거로 돌아갈 수 없습니다."),
+    NOT_ALLOWED_LLM_SERVER(90200, "허용되지 않은 LLM 서버 연결입니다"),
 
     /**
      * Member Exception

--- a/src/main/java/com/dft/mom/web/filter/authorization/JwtAuthorizationRsaFilter.java
+++ b/src/main/java/com/dft/mom/web/filter/authorization/JwtAuthorizationRsaFilter.java
@@ -61,7 +61,6 @@ public class JwtAuthorizationRsaFilter extends OncePerRequestFilter {
     ) throws IOException, ServletException {
         try {
             String token = getToken(request);
-
             if (token == null) {
                 setException(request, TOKEN_NOT_EXIST, chain, response);
                 return;
@@ -136,7 +135,7 @@ public class JwtAuthorizationRsaFilter extends OncePerRequestFilter {
             return true;
         }
 
-        return POSSIBLE_GET_ROUTE.contains(request.getRequestURI());
+        return VALIDATE_GET_ROUTE.contains(request.getRequestURI());
     }
 
     private void validateNonMember(

--- a/src/main/java/com/dft/mom/web/filter/security/BlacklistFilter.java
+++ b/src/main/java/com/dft/mom/web/filter/security/BlacklistFilter.java
@@ -10,6 +10,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
@@ -17,36 +18,34 @@ import static com.dft.mom.domain.function.FunctionUtil.getClientIp;
 import static com.dft.mom.web.exception.ExceptionType.BLOCKED_IP;
 
 @Component
-@Order(1)
 @RequiredArgsConstructor
-public class BlacklistFilter implements Filter {
+public class BlacklistFilter extends OncePerRequestFilter {
 
     private final BlacklistService blacklistService;
     private final AuthenticationEntryPoint authenticationEntryPoint;
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-            throws IOException, ServletException {
-        HttpServletRequest httpRequest = (HttpServletRequest) request;
-        HttpServletResponse httpResponse = (HttpServletResponse) response;
-        String clientIp = getClientIp(httpRequest);
-        String requestUri = httpRequest.getRequestURI();
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        String clientIp  = getClientIp(request);
+        String requestUri = request.getRequestURI();
 
         try {
             if (blacklistService.isBlacklisted(clientIp)) {
-                httpRequest.setAttribute("exception", BLOCKED_IP);
+                request.setAttribute("exception", BLOCKED_IP);
                 throw new CommonException(BLOCKED_IP.getCode(), BLOCKED_IP.getErrorMessage());
             }
 
             if (!isValidUrl(requestUri)) {
                 blacklistService.addToBlacklist(clientIp);
-                httpRequest.setAttribute("exception", BLOCKED_IP);
+                request.setAttribute("exception", BLOCKED_IP);
                 throw new CommonException(BLOCKED_IP.getCode(), BLOCKED_IP.getErrorMessage());
             }
 
             chain.doFilter(request, response); }
         catch (Exception e) {
-            authenticationEntryPoint.commence(httpRequest, httpResponse, new AuthenticationException(e.getMessage()) {});
+            authenticationEntryPoint.commence(request, response, new AuthenticationException(e.getMessage()) {});
         }
     }
 

--- a/src/main/java/com/dft/mom/web/filter/security/LLMAuthFilter.java
+++ b/src/main/java/com/dft/mom/web/filter/security/LLMAuthFilter.java
@@ -1,0 +1,43 @@
+package com.dft.mom.web.filter.security;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class LLMAuthFilter extends OncePerRequestFilter {
+
+    @Value("${oauth.header-name}")
+    private String headerName;
+
+    @Value("${oauth.new-secret}")
+    private String newSecret;
+
+    @Value("${oauth.old-secret}")
+    private String oldSecret;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (!request.getServletPath().startsWith("/oauth")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String secret = request.getHeader(headerName);
+        if (secret == null ||
+                !(secret.equals(newSecret) || secret.equals(oldSecret))) {
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/dft/mom/web/filter/security/LLMAuthFilter.java
+++ b/src/main/java/com/dft/mom/web/filter/security/LLMAuthFilter.java
@@ -1,5 +1,6 @@
 package com.dft.mom.web.filter.security;
 
+import com.dft.mom.web.exception.CommonException;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,6 +10,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+
+import static com.dft.mom.web.exception.ExceptionType.NOT_ALLOWED_LLM_SERVER;
+import static com.dft.mom.web.exception.ExceptionType.TOKEN_EXPIRED;
 
 @Component
 @RequiredArgsConstructor
@@ -35,7 +39,8 @@ public class LLMAuthFilter extends OncePerRequestFilter {
         String secret = request.getHeader(headerName);
         if (secret == null ||
                 !(secret.equals(newSecret) || secret.equals(oldSecret))) {
-            return;
+            request.setAttribute("exception", NOT_ALLOWED_LLM_SERVER);
+            throw new CommonException(NOT_ALLOWED_LLM_SERVER.getCode(), NOT_ALLOWED_LLM_SERVER.getErrorMessage());
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -2,6 +2,11 @@ server:
   id: 1
   type: test
 
+oauth:
+  header-name: X-Internal-Secret
+  new-secret: abcde
+  old-secret: abcde
+
 spring:
   config.activate.on-profile: test
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ server:
   id: 1
   type: ${SERVER_TYPE:prod}
 
+oauth:
+  header-name: X-Internal-Secret
+  new-secret: ${AUTH_NEW_SECRET:abcde}
+  old-secret: ${AUTH_OLD_SECRET:abcde}
+
 spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/momagent}

--- a/src/test/java/com/dft/mom/domain/security/FilterTest.java
+++ b/src/test/java/com/dft/mom/domain/security/FilterTest.java
@@ -1,0 +1,115 @@
+package com.dft.mom.domain.security;
+
+import com.dft.mom.ServiceTest;
+import com.dft.mom.domain.dto.baby.req.ParentingCreateRequestDto;
+import com.dft.mom.domain.dto.baby.req.PregnancyCreateRequestDto;
+import com.dft.mom.domain.dto.member.req.MemberCreateRequestDto;
+import com.dft.mom.domain.dto.member.res.MemberStatusResponseDto;
+import com.dft.mom.domain.dto.member.res.TokenResponseDto;
+import com.dft.mom.domain.entity.member.Member;
+import com.dft.mom.domain.service.LoginService;
+import com.dft.mom.domain.service.MemberService;
+import com.dft.mom.web.exception.ErrorResult;
+import com.dft.mom.web.exception.member.MemberException;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.Key;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static com.dft.mom.CreateUtil.*;
+import static com.dft.mom.domain.util.CommonConstants.ACCESS_TOKEN;
+import static com.dft.mom.domain.util.EntityConstants.MEMBER_STR;
+import static com.dft.mom.domain.util.EntityConstants.NON_MEMBER_STR;
+import static com.dft.mom.web.exception.ExceptionType.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class FilterTest extends ServiceTest {
+
+    @Autowired
+    private LoginService loginService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    public Member 회원1;
+    public String 비회원엑세스토큰;
+    public String 비회원리프리시토큰;
+
+    public String 회원1엑세스토큰;
+    public String 회원1리프레시토큰;
+
+    @BeforeEach
+    public void setUp() {
+        List<PregnancyCreateRequestDto> 임신중아이리스트 = createPregnancyListCreateRequestDto(LocalDate.now().plusDays(30), null, 3);
+        MemberCreateRequestDto 회원생성요청1 = createMemberCreateRequestDto(null, 임신중아이리스트, null);
+
+        회원1 = memberService.createMember(회원생성요청1, UUID.randomUUID().toString());
+
+        flushAndClear();
+
+        TokenResponseDto 비회원토큰 = loginService.createToken(UUID.randomUUID().toString(), NON_MEMBER_STR);
+        TokenResponseDto 회원1토큰 = loginService.createToken(회원1);
+        비회원엑세스토큰 = 비회원토큰.getAccessToken();
+        비회원리프리시토큰 = 비회원토큰.getRefreshToken();
+        회원1엑세스토큰 = 회원1토큰.getAccessToken();
+        회원1리프레시토큰 = 회원1토큰.getRefreshToken();
+
+        flushAndClear();
+    }
+
+    @Test
+    @DisplayName("1.GET /oauth - 해피 케이스 - 비회원 보안키 검증 성공")
+    void 보안키_검증에_성공하면_요청이_성공한다() {
+        // given when
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(비회원엑세스토큰);
+        headers.add("X-Internal-Secret", "abcde");
+        HttpEntity<Void> 요청헤더 = new HttpEntity<>(headers);
+
+        ResponseEntity<Void> response = restTemplate
+                .exchange("/oauth", HttpMethod.GET, 요청헤더, Void.class);
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("2.GET /oauth - 엣지 케이스 - 비회원 보안키 검증 실패")
+    void 보안키_검증에_실패하면_예외가_발생한다() {
+        // given when
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(비회원엑세스토큰);
+        headers.add("X-Internal-Secret", "abc");
+        HttpEntity<Void> 요청헤더 = new HttpEntity<>(headers);
+
+        ResponseEntity<ErrorResult> response = restTemplate
+                .exchange("/oauth", HttpMethod.GET, 요청헤더, ErrorResult.class);
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo(NOT_ALLOWED_LLM_SERVER.getCode());
+        assertThat(response.getBody().getErrorMessage()).isEqualTo(NOT_ALLOWED_LLM_SERVER.getErrorMessage());
+    }
+}

--- a/src/test/java/com/dft/mom/service/OAuthServiceTest.java
+++ b/src/test/java/com/dft/mom/service/OAuthServiceTest.java
@@ -39,15 +39,28 @@ public class OAuthServiceTest extends ServiceTest {
     }
 
     @Test
-    @DisplayName("1. 비회원은 5번까지 접근이 가능하다.")
+    @DisplayName("1. 비회원은 3번까지 접근이 가능하다.")
     public void 비회원은_다섯번까지_접근이_가능하다() {
         assertDoesNotThrow(() -> {
-            for (int i = 0; i < 5; i++) {
+            for (int i = 0; i < 3; i++) {
                 authService.increaseAndValidate("1", NON_MEMBER_STR);
             }
         });
 
         MemberException ex = assertThrows(MemberException.class, () -> authService.increaseAndValidate("1", NON_MEMBER_STR));
         assertEquals(MORE_FOR_MEMBER.getCode(), ex.getCode());
+    }
+
+    @Test
+    @DisplayName("2. 회원은 15번까지 접근이 가능하다.")
+    public void 비회원은_15번까지_접근이_가능하다() {
+        assertDoesNotThrow(() -> {
+            for (int i = 0; i < 15; i++) {
+                authService.increaseAndValidate("1", MEMBER_STR);
+            }
+        });
+
+        MemberException ex = assertThrows(MemberException.class, () -> authService.increaseAndValidate("1", MEMBER_STR));
+        assertEquals(QUOTA_EXCEED.getCode(), ex.getCode());
     }
 }


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] 기존 JWT 토큰 방식에 추가적으로 보안키를 추가하여 API 서버와 LLM 서버 사이의 통신 보안을 강화
- [x] 보안 키 변경시 타이밍 문제를 개선하기 위해 OLD 보안키와 NEW 보안 키로 관리  

## 고민과 해결과정
### JWT 토큰만으로 괜찮을까?
LLM 서버가 API 서버로 요청을 보낼때, JWT 방식을 사용했지만 토큰은 언제든지 탈취당할 위험이있다.
또한 토큰의 경우 탈취당했을때 서버에서 제어권이 없으므로 이를 위해 추가적인 보안이 필요하다.
따라서 LLM 서버와 API 서버가 각 서버에서 관리하는 보안키를 통해 서로의 요청을 보장한다.

### 보안키가 변경되는 타이밍
보안키도 만약 탈취당할 수 있다. 그렇다면 해당 키도 주기적으로 바꿔줘야 한다.
하지만 보안키를 업데이트할 경우, 하나의 서버에서 발생한 보안키 업데이트가 다른 서버에도 적용되기 전까지 공백이 발생할 수 있다.
즉, 서로가 가진 보안키가 타이밍 문제로 일치하지 않을 수 있는 것이다.
따라서 보안키를 검증하는 스프링 서버에서 OLD 버전의 보안키와 NEW 버전의 보안키를 관리한다. 이후 새로운 보안키를 생성하면 이 키를 NEW 버전으로 만들고, 기존 NEW 버전 키를 OLD 버전으로 이동시킨다.
이렇게 함으로 LLM 서버가 업데이트 지연으로 기존의 KEY를 보내더라도 크게 문제가 되지 않는다.