### PR TITLE
[FEAT]: admin 토큰 발급 기능 구현

### DIFF
--- a/src/main/java/com/dft/mom/domain/dto/member/req/AdminRequestDto.java
+++ b/src/main/java/com/dft/mom/domain/dto/member/req/AdminRequestDto.java
@@ -1,0 +1,15 @@
+package com.dft.mom.domain.dto.member.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminRequestDto {
+
+    private String secret;
+}

--- a/src/main/java/com/dft/mom/web/config/SpringSecurityConfig.java
+++ b/src/main/java/com/dft/mom/web/config/SpringSecurityConfig.java
@@ -38,6 +38,7 @@ public class SpringSecurityConfig {
                 "/",
                 "/auth/kakao",
                 "/auth/login/non",
+                "/auth/login/admin",
                 "/auth/apple",
                 "/common/version-check"
         };

--- a/src/main/java/com/dft/mom/web/filter/authorization/JwtAuthorizationRsaFilter.java
+++ b/src/main/java/com/dft/mom/web/filter/authorization/JwtAuthorizationRsaFilter.java
@@ -50,6 +50,7 @@ public class JwtAuthorizationRsaFilter extends OncePerRequestFilter {
                 || pathMatcher.match("/auth/apple", path)
                 || pathMatcher.match("/auth/kakao", path)
                 || pathMatcher.match("/auth/login/non", path)
+                || pathMatcher.match("/auth/login/admin", path)
                 || pathMatcher.match("/common/version-check", path));
     }
 

--- a/src/main/java/com/dft/mom/web/filter/security/LLMAuthFilter.java
+++ b/src/main/java/com/dft/mom/web/filter/security/LLMAuthFilter.java
@@ -12,7 +12,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 
 import static com.dft.mom.web.exception.ExceptionType.NOT_ALLOWED_LLM_SERVER;
-import static com.dft.mom.web.exception.ExceptionType.TOKEN_EXPIRED;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -2,6 +2,9 @@ server:
   id: 1
   type: test
 
+admin:
+  secret: 1234
+
 oauth:
   header-name: X-Internal-Secret
   new-secret: abcde

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ server:
   id: 1
   type: ${SERVER_TYPE:prod}
 
+admin:
+  secret: ${ADMIN_SECRET:1234}
+
 oauth:
   header-name: X-Internal-Secret
   new-secret: ${AUTH_NEW_SECRET:abcde}


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] 보안을 위해 시크릿 키를 통해 토큰 발급

## 고민과 해결과정
### 어드민 토큰을 발급 받기 위한 보안으로 뭐가 좋을까?
IP 비교 등 다양한 방식을 고려했지만, 보안키 발급 방식과 비슷하게 보안 시크릿 키를 통해 구현했다.
임시 방편으로 만들었으나 추가 보안을 확보할 필요가 있다.

추후 Presigned URL 방식을 도입해볼 예정이다. 이 방식은 요청이 들어왔을때 해당 요청을 처리할 수 있는 미리 서명된 URL 정보를 주고, 그 Presigned URL을 통해서 클라이언트가 S3로 직접 업로드 하는 방식이다.

따라서 토큰 방식에서도 이를 통해 먼저 어드민 토큰을 발급 받을 수 있는 정보를 생성하여 클라리언트로 보내고, 클라이언트가 해당 정보를 통해 다시 요청을 보내야지 토큰을 발급받을 수 있도록 보안을 일부 높일 수 있을 것 같다.